### PR TITLE
Pass the orderId in the create command, instead of generating one in the constructor

### DIFF
--- a/src/OrdersCollector.Core/Orders/CommandHandlers/CreateOrderCommandHandler.cs
+++ b/src/OrdersCollector.Core/Orders/CommandHandlers/CreateOrderCommandHandler.cs
@@ -26,7 +26,7 @@ namespace OrdersCollector.Core.Orders.CommandHandlers
 
             // TODO: validate that user has permission to create order
             // in the specified group
-            var order = new Order(message.SupplierId, message.GroupId);
+            var order = new Order(message.OrderId, message.SupplierId, message.GroupId);
             await repository.Save(order);
         }
     }

--- a/src/OrdersCollector.Core/Orders/Commands/CreateOrderCommand.cs
+++ b/src/OrdersCollector.Core/Orders/Commands/CreateOrderCommand.cs
@@ -6,12 +6,15 @@ namespace OrdersCollector.Core.Orders.Commands
     public class CreateOrderCommand : IRequest
     {
 
-        public CreateOrderCommand(Guid groupId, Guid supplierId, Guid userId)
+        public CreateOrderCommand(Guid orderId, Guid groupId, Guid supplierId, Guid userId)
         {
+            this.OrderId = orderId;
             this.GroupId = groupId;
             this.SupplierId = supplierId;
             this.UserId = userId;
         }
+
+        public Guid OrderId { get; }
 
         public Guid GroupId { get; }
 

--- a/src/OrdersCollector.Core/Orders/Models/Order.cs
+++ b/src/OrdersCollector.Core/Orders/Models/Order.cs
@@ -8,12 +8,13 @@ namespace OrdersCollector.Core.Orders.Models
     public class Order : AggregateRoot
     {
         public Order(
+            Guid orderId,
             Guid supplierId,
             Guid groupId
         ) : this()
         {
             RaiseEvent(new OrderCreated(
-                Guid.NewGuid(),
+                orderId,
                 supplierId,
                 groupId
             ));

--- a/test/OrdersCollector.Core.Tests/Builders/CreateOrderCommandBuilder.cs
+++ b/test/OrdersCollector.Core.Tests/Builders/CreateOrderCommandBuilder.cs
@@ -5,12 +5,14 @@ namespace OrdersCollector.Core.Tests.Builders
 {
     public class CreateOrderCommandBuilder
     {
+        private Guid orderId;
         private Guid groupId;
         private Guid supplierId;
         private Guid userId;
 
         public CreateOrderCommandBuilder()
         {
+            orderId = Guid.NewGuid();
             groupId = Guid.NewGuid();
             supplierId = Guid.NewGuid();
             userId = Guid.NewGuid();
@@ -19,6 +21,7 @@ namespace OrdersCollector.Core.Tests.Builders
         public CreateOrderCommand Build()
         {
             return new CreateOrderCommand(
+                orderId,
                 groupId,
                 supplierId,
                 userId);

--- a/test/OrdersCollector.Core.Tests/Orders/CommandHandlers/CreateOrderCommandHandlerTests/HandleTestFixture.cs
+++ b/test/OrdersCollector.Core.Tests/Orders/CommandHandlers/CreateOrderCommandHandlerTests/HandleTestFixture.cs
@@ -18,7 +18,6 @@ namespace OrdersCollector.Core.Tests.Orders.CommandHandlers
         public void SetUp()
         {
             repository = Substitute.For<IAggregateRepository<Order>>();
-            repository.Get(Guid.NewGuid()).Returns(new Order(Guid.NewGuid(), Guid.NewGuid()));
         }
 
         [Test]
@@ -48,7 +47,8 @@ namespace OrdersCollector.Core.Tests.Orders.CommandHandlers
             // Assert
             await repository.Received().Save(
                 Arg.Is<Order>(
-                    o => o.GroupId == command.GroupId &&
+                    o => o.Id == command.OrderId &&
+                         o.GroupId == command.GroupId &&
                          o.SupplierId == command.SupplierId));
         }
 

--- a/test/OrdersCollector.Core.Tests/Orders/Models/OrderTests/ConstructorTestFixture.cs
+++ b/test/OrdersCollector.Core.Tests/Orders/Models/OrderTests/ConstructorTestFixture.cs
@@ -8,31 +8,33 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
 {
     public class ConstructorTestFixture
     {
+        private Guid orderId;
         private Guid supplierId;
         private Guid groupId;
 
         [SetUp]
         public void SetUp()
         {
+            orderId = Guid.NewGuid();
             supplierId = Guid.NewGuid();
             groupId = Guid.NewGuid();
         }
 
         [Test]
-        public void Constructor_WhenInvoked_MustCreateOrderWithGeneratedId()
+        public void Constructor_WhenInvoked_MustCreateOrderWithOrderId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
-            Assert.That(subject.Id, Is.Not.EqualTo(Guid.Empty));
+            Assert.That(subject.Id, Is.EqualTo(orderId));
         }
 
         [Test]
         public void Constructor_WhenInvoked_MustCreateOrderWithSupplierId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             Assert.That(subject.SupplierId, Is.EqualTo(supplierId));
@@ -42,7 +44,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustCreateOrderWithGroupId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             Assert.That(subject.GroupId, Is.EqualTo(groupId));
@@ -52,7 +54,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustCreateOrderWithStatusSetToDraft()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             Assert.That(subject.Status, Is.EqualTo(OrderStatus.Draft));
@@ -62,7 +64,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustAddCreatedEventToUncommitedEvents()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             var @event = subject.GetUncommitedChanges().Single();
@@ -73,7 +75,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustAddCreatedEventWithSupplierId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             var @event = subject.GetUncommitedChanges().Single() as OrderCreated;
@@ -84,7 +86,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustAddCreatedEventWithGroupId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             var @event = subject.GetUncommitedChanges().Single() as OrderCreated;
@@ -95,7 +97,7 @@ namespace OrdersCollector.Core.Tests.Orders.Models.OrderTests
         public void Constructor_WhenInvoked_MustAddCreatedEventWithOrderId()
         {
             // Arrange, Act
-            var subject = new Order(supplierId, groupId);
+            var subject = new Order(orderId, supplierId, groupId);
 
             // Assert
             var @event = subject.GetUncommitedChanges().Single() as OrderCreated;


### PR DESCRIPTION
CreateOrderCommand now includes the order id, so that it doesn't need to be returned to the issuer of the command. Returning the order id would violate CQRS. 